### PR TITLE
feat: add basic authentication to protect admin routes

### DIFF
--- a/client/src/routes/admin/login/+page.svelte
+++ b/client/src/routes/admin/login/+page.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+  import { goto } from '$app/navigation';
+  let username = '';
+  let password = '';
+  let loading = false;
+  let error = ''
+
+  async function handleLogin() {
+    loading = true;
+    error = '';
+    const res = await fetch('http://localhost:3000/admin/login', {
+      headers: {
+        'Authorization': `Basic ${username}:${password}`
+      },
+      method: "POST",
+    });
+    if (res.ok) {
+      // ideally this shouldn't be stored in localStorage for security reasons, but we want a minimal solution. Can be improved later.
+      localStorage.setItem("credentials", `${username}:${password}`);
+      goto('/admin/events');
+    } else {
+      error = 'Invalid username or password';
+    }
+    loading = false;
+  }
+</script>
+
+<main class="flex flex-col items-center py-8 min-h-screen">
+  <h1 class="text-2xl font-bold mb-8 text-primary dark:text-primary-darkmode font-inter">Admin Login</h1>
+  <form class="w-full max-w-md rounded-xl shadow p-6 flex flex-col gap-3 font-inter bg-surface dark:bg-gray-800 sm:bg-surface sm:dark:bg-gray-800 bg-background dark:dark:bg-gray-800" on:submit|preventDefault={handleLogin} autocomplete="off">
+    <div>
+      <label for="name" class="block mb-1 font-semibold">Username<span class="text-red-500 ml-1" aria-hidden="true">*</span></label>
+      <input id="name" name="name" type="text" bind:value={username} required aria-required="true" aria-label="Event Name" class="w-full px-4 py-2 rounded border border-gray-300 focus:outline-none focus:ring-2 focus:ring-primary dark:bg-background-dark dark:border-gray-700 dark:text-text-dark" />
+    </div>
+    <div>
+      <label for="password" class="block mb-1 font-semibold">Password<span class="text-red-500 ml-1" aria-hidden="true">*</span></label>
+      <input id="password" name="password" type="password" bind:value={password} required aria-required="true" aria-label="Password" class="w-full px-4 py-2 rounded border border-gray-300 focus:outline-none focus:ring-2 focus:ring-primary dark:bg-background-dark dark:border-gray-700 dark:text-text-dark" />
+    </div>
+
+    {#if error}
+      <div class="text-red-600 text-center text-sm font-semibold mb-2">{error}</div>
+    {/if}
+    <button type="submit" class="mt-4 px-6 py-2 bg-primary text-white rounded font-bold shadow hover:bg-primary-dark transition-colors dark:bg-primary-darkmode dark:hover:bg-primary-darkmode-hover flex items-center justify-center min-w-[140px]" aria-label="Create Event" disabled={loading}>
+      {#if loading}
+        <span class="relative flex h-5 w-5 mr-2">
+          <span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-white opacity-75"></span>
+          <span class="relative inline-flex rounded-full h-5 w-5 bg-white"></span>
+        </span>
+        Loading...
+      {:else}
+        Submit
+      {/if}
+    </button>
+  </form>
+
+</main>

--- a/client/src/routes/create-event/+page.svelte
+++ b/client/src/routes/create-event/+page.svelte
@@ -17,7 +17,7 @@
     }
     loading = true;
     try {
-      const response = await fetch('http://localhost:3000/create-event', {
+      const response = await fetch('http://localhost:3000/admin/create-event', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ name, date, startTime, endTime, maxAttendees, location })

--- a/server/package.json
+++ b/server/package.json
@@ -2,7 +2,9 @@
   "name": "server",
   "packageManager": "yarn@4.9.2",
   "dependencies": {
+    "@types/dotenv": "^8.2.3",
     "cors": "^2.8.5",
+    "dotenv": "^17.2.1",
     "express": "^5.1.0",
     "express-rate-limit": "^8.0.1",
     "pg": "^8.16.3",

--- a/server/src/config/index.ts
+++ b/server/src/config/index.ts
@@ -1,0 +1,13 @@
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const config = {
+  NODE_ENV: process.env.NODE_ENV,
+  PORT: process.env.PORT,
+  DATABASE_URL: process.env.DATABASE_URL,
+  ADMIN_USER: process.env.ADMIN_USER,
+  ADMIN_PASSWORD: process.env.ADMIN_PASSWORD
+};
+
+export default config;

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -16,7 +16,6 @@ const limiter = rateLimit({
   ipv6Subnet: 56,
 })
 
-
 app.use(limiter)
 app.use(cors());
 app.use(express.json());

--- a/server/src/middlewares/auth.ts
+++ b/server/src/middlewares/auth.ts
@@ -8,6 +8,7 @@ export function authenticateAdmin(req: Request, res: Response, next: NextFunctio
     return res.status(401).json({ error: 'Authorization header missing or invalid' });
   }
   const credentials = authHeader.replace('Basic ', '');
+
   if (
     credentials !== `${config.ADMIN_USER}:${config.ADMIN_PASSWORD}`
   ) {

--- a/server/src/middlewares/auth.ts
+++ b/server/src/middlewares/auth.ts
@@ -1,0 +1,17 @@
+import { Request, Response, NextFunction } from 'express';
+import config from '../config';
+
+// Middleware to authenticate admin using 'Basic USER:PASS' from Authorization header
+export function authenticateAdmin(req: Request, res: Response, next: NextFunction) {
+  const authHeader = req.headers['authorization'];
+  if (!authHeader || !authHeader.startsWith('Basic ')) {
+    return res.status(401).json({ error: 'Authorization header missing or invalid' });
+  }
+  const credentials = authHeader.replace('Basic ', '');
+  if (
+    credentials !== `${config.ADMIN_USER}:${config.ADMIN_PASSWORD}`
+  ) {
+    return res.status(403).json({ error: 'Invalid credentials' });
+  }
+  next();
+}

--- a/server/src/routes.ts
+++ b/server/src/routes.ts
@@ -1,13 +1,17 @@
 import { Router } from "express";
 import { eventController } from "./controllers/eventController";
 import { rsvpController } from './controllers/rsvpController';
+import {authenticateAdmin} from "./middlewares/auth";
 
 const router = Router();
 
-router.post("/create-event", eventController.createEvent);
+// Admin routes
+router.post("/admin/create-event", authenticateAdmin, eventController.createEvent);
+router.get("/admin/events", authenticateAdmin, eventController.getAllEvents);
+router.delete("/admin/events/:id", authenticateAdmin, eventController.deleteEvent);
+
+// Public routes
 router.get("/events/:id", eventController.getEventById);
 router.post("/events/:id/rsvp", rsvpController.rsvpToEvent);
-router.get("/admin/events", eventController.getAllEvents);
-router.delete("/admin/events/:id", eventController.deleteEvent);
 
 export default router;

--- a/server/src/routes.ts
+++ b/server/src/routes.ts
@@ -6,6 +6,7 @@ import {authenticateAdmin} from "./middlewares/auth";
 const router = Router();
 
 // Admin routes
+router.post("/admin/login", authenticateAdmin, (_, res) => res.status(200).send())
 router.post("/admin/create-event", authenticateAdmin, eventController.createEvent);
 router.get("/admin/events", authenticateAdmin, eventController.getAllEvents);
 router.delete("/admin/events/:id", authenticateAdmin, eventController.deleteEvent);

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -94,6 +94,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/dotenv@npm:^8.2.3":
+  version: 8.2.3
+  resolution: "@types/dotenv@npm:8.2.3"
+  dependencies:
+    dotenv: "npm:*"
+  checksum: 10c0/af9178da617959cddc8259aaa3f16c474523ead469f4a03490de2f2d1cafc8615c5d0d1ed3fad837096218126421c38cd46b4065548bb5aee3cc002c518b69f7
+  languageName: node
+  linkType: hard
+
 "@types/express-serve-static-core@npm:^5.0.0":
   version: 5.0.7
   resolution: "@types/express-serve-static-core@npm:5.0.7"
@@ -335,6 +344,13 @@ __metadata:
   version: 4.0.2
   resolution: "diff@npm:4.0.2"
   checksum: 10c0/81b91f9d39c4eaca068eb0c1eb0e4afbdc5bb2941d197f513dd596b820b956fef43485876226d65d497bebc15666aa2aa82c679e84f65d5f2bfbf14ee46e32c1
+  languageName: node
+  linkType: hard
+
+"dotenv@npm:*, dotenv@npm:^17.2.1":
+  version: 17.2.1
+  resolution: "dotenv@npm:17.2.1"
+  checksum: 10c0/918dd2f9d8b8f86b0afabad9534793d51de3718c437f9e7b6525628cf68c1d4ae768cc37a5afff38c066f58a8ecf549f4ac6cd5617485bd328e826112cc2650a
   languageName: node
   linkType: hard
 
@@ -898,10 +914,12 @@ __metadata:
   resolution: "server@workspace:."
   dependencies:
     "@types/cors": "npm:^2"
+    "@types/dotenv": "npm:^8.2.3"
     "@types/express": "npm:^5.0.3"
     "@types/node": "npm:^24.2.1"
     "@types/pg": "npm:^8"
     cors: "npm:^2.8.5"
+    dotenv: "npm:^17.2.1"
     express: "npm:^5.1.0"
     express-rate-limit: "npm:^8.0.1"
     pg: "npm:^8.16.3"


### PR DESCRIPTION
## Description

Added a super basic authentication mechanism to protect the `/admin/*` routes

All admin requests are expected to have a `Authorization` header of form `Basic <USER>:<PASS>`

Currently, only supports a single admin user. I don't think we need multiple admin roles right now. So the credentials simply come from the env

Its super simple but some authentication is better than none 😅 